### PR TITLE
Refactor imports for clarity and grouping

### DIFF
--- a/tapestry/assembly.py
+++ b/tapestry/assembly.py
@@ -27,27 +27,40 @@
 # SOFTWARE.
 
 
-import os, sys, json, datetime
+import datetime
+import json
+import os
+import sys
 import logging as log
-
-from multiprocessing import Pool
-from functools import partial
-from statistics import mean, median
 from collections import defaultdict
+from functools import partial
 from gzip import open as gzopen
-from tqdm import tqdm
 from math import log10
+from multiprocessing import Pool
+from statistics import mean
+from statistics import median
 
-from Bio import SeqIO, motifs
+from Bio import SeqIO
+from Bio import motifs
 from Bio.Seq import Seq
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
+from tqdm import tqdm
 
-from jinja2 import Environment, FileSystemLoader
-
-from .contig import Contig, process_contig, get_ploidy
 from .alignments import Alignments
-from .misc import cached_property, setup_output, include_file, report_folder, tapestry_tqdm, file_exists, is_gz_file
-from .misc import minimap2, samtools
+from .contig import Contig
+from .contig import get_ploidy
+from .contig import process_contig
+from .misc import cached_property
+from .misc import file_exists
+from .misc import include_file
+from .misc import is_gz_file
+from .misc import minimap2
+from .misc import report_folder
+from .misc import samtools
+from .misc import setup_output
+from .misc import tapestry_tqdm
 from ._version import __version__
 
 filenames = {

--- a/tapestry/contig.py
+++ b/tapestry/contig.py
@@ -27,11 +27,15 @@
 # SOFTWARE.
 
 
-import os, re, warnings
+import os
+import re
+import warnings
+from collections import Counter
+from collections import defaultdict
 from statistics import mean
-from collections import Counter, defaultdict
 
-from intervaltree import Interval, IntervalTree
+from intervaltree import Interval
+from intervaltree import IntervalTree
 
 from .alignments import Alignments
 
@@ -182,7 +186,7 @@ class Contig:
                         # if s is directly searchable as a sequence (string)
                         start_matches += self.rec[:1000].seq.count(str(s))
                         end_matches += self.rec[-1000:].seq.count(str(s))
-      return start_matches, end_matches
+        return start_matches, end_matches
 
 
     def get_contig_alignments(self):

--- a/tapestry/misc.py
+++ b/tapestry/misc.py
@@ -27,14 +27,24 @@
 # SOFTWARE.
 
 
-from ._version import __version__
-
-import os, sys, argparse, itertools, errno, io, binascii, pkg_resources
+import argparse
+import binascii
+import errno
+import io
+import itertools
 import logging as log
-from functools import partial, lru_cache
-from tqdm import tqdm
+import os
+import sys
+from functools import lru_cache
+from functools import partial
+
+import pkg_resources
 from Bio import SeqIO
-from plumbum import local, CommandNotFound
+from plumbum import CommandNotFound
+from plumbum import local
+from tqdm import tqdm
+
+from ._version import __version__
 
 failed = []
 tools = {'minimap2':'minimap2', 


### PR DESCRIPTION
## Summary
- Separate combined imports across core modules
- Group imports by standard library, third-party, and local modules

## Testing
- `python -m py_compile tapestry/assembly.py tapestry/contig.py tapestry/misc.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d82350f48321b7d31be76a1f3905