### PR TITLE
Use builtin cached_property

### DIFF
--- a/tapestry/assembly.py
+++ b/tapestry/assembly.py
@@ -33,7 +33,7 @@ import os
 import sys
 import logging as log
 from collections import defaultdict
-from functools import partial
+from functools import cached_property, partial
 from gzip import open as gzopen
 from math import log10
 from multiprocessing import Pool
@@ -52,7 +52,6 @@ from .alignments import Alignments
 from .contig import Contig
 from .contig import get_ploidy
 from .contig import process_contig
-from .misc import cached_property
 from .misc import file_exists
 from .misc import include_file
 from .misc import is_gz_file

--- a/tapestry/misc.py
+++ b/tapestry/misc.py
@@ -35,8 +35,7 @@ import itertools
 import logging as log
 import os
 import sys
-from functools import lru_cache
-from functools import partial
+from functools import cached_property, partial
 
 import pkg_resources
 from Bio import SeqIO
@@ -183,10 +182,6 @@ def file_exists(filename, deps=[]):
 def is_gz_file(filepath):
     with open(filepath, 'rb') as test_f:
         return binascii.hexlify(test_f.read(2)) == b'1f8b'
-
-
-def cached_property(function):
-    return property(lru_cache()(function))
 
 
 def include_file(filename):


### PR DESCRIPTION
## Summary
- drop custom cached_property implementation
- import and use functools.cached_property directly in modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891db8ee3c48321bc114abc29bccfef