### PR TITLE
Remove unused variable from alignment loading

### DIFF
--- a/tapestry/alignments.py
+++ b/tapestry/alignments.py
@@ -226,7 +226,6 @@ class Alignments():
             
                     chunk_count += 1
                     if chunk_count == 1000:
-                        ids = list(map(lambda x: x['id'], alignment_chunk))
                         conn.execute(self.alignments.insert(), alignment_chunk)
                         chunk_count = 0
                         alignment_chunk = []


### PR DESCRIPTION
## Summary
- remove unused ids variable from batched alignment insertion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892187fdd748321b816a1df5edc2c94