### PR TITLE
Replace bare excepts and sys.exit calls

### DIFF
--- a/tapestry/alignments.py
+++ b/tapestry/alignments.py
@@ -146,8 +146,9 @@ class Alignments():
 
                 conn.execute(self.contigs.insert(), contig_rows)
                 conn.execute(self.ranges.insert(), ranges_rows)
-        except:
-            log.error(f"Failed to add assembly to alignments database {self.db_filename}")
+        except Exception as e:
+            log.error(f"Failed to add assembly to alignments database {self.db_filename}: {e}")
+            raise
 
 
     def load_alignments(self, bam_filename, query_type=None, min_contig_alignment=None):
@@ -238,8 +239,9 @@ class Alignments():
                 if reads_chunk:
                     conn.execute(self.reads.insert(), reads_chunk)
 
-        except:
-            log.error(f"Failed to add {query_type} alignments to database {self.db_filename}")
+        except Exception as e:
+            log.error(f"Failed to add {query_type} alignments to database {self.db_filename}: {e}")
+            raise
 
 
     def get_alignment_type(self, aln):

--- a/tapestry/misc.py
+++ b/tapestry/misc.py
@@ -34,7 +34,6 @@ import io
 import itertools
 import logging as log
 import os
-import sys
 from functools import cached_property, partial
 
 import pkg_resources
@@ -62,9 +61,12 @@ for tool in tools:
 if failed:
     dep = 'dependency' if len(failed)==1 else 'dependencies'
     itthey = 'it is' if len(failed)==1 else 'they are'
-    print(f"Tapestry can't find the following {dep}. Please check {itthey} installed and try again.")
-    print('\n'.join(failed))
-    sys.exit()
+    message = (
+        f"Tapestry can't find the following {dep}. Please check {itthey} installed and try again.\n"
+        + '\n'.join(failed)
+    )
+    log.error(message)
+    raise RuntimeError(message)
 
 
 report_folder = pkg_resources.resource_filename(__name__, 'report')
@@ -86,7 +88,7 @@ def get_args(arglist=None, description="", scriptargs=None):
     # If no arguments, print usage message
     if not arglist:
         parser.print_help()
-        sys.exit()
+        raise ValueError("No arguments provided")
 
     args = parser.parse_args(arglist)
 
@@ -94,7 +96,7 @@ def get_args(arglist=None, description="", scriptargs=None):
 
     if args.cores < 1:
         log.error("Please specify at least one core")
-        sys.exit()
+        raise ValueError("Please specify at least one core")
 
     return args
 
@@ -114,16 +116,19 @@ def get_weave_args(arglist=None):
             "'-o', '--output', help='directory to write output, default weave_output', type=str, default='weave_output'"])
 
     if not file_exists(args.assembly):
-        log.error(f"Assembly file {args.assembly} does not exist")
-        sys.exit()
+        msg = f"Assembly file {args.assembly} does not exist"
+        log.error(msg)
+        raise FileNotFoundError(msg)
 
     if not file_exists(args.reads):
-        log.error(f"Reads file {args.reads} does not exist")
-        sys.exit()
+        msg = f"Reads file {args.reads} does not exist"
+        log.error(msg)
+        raise FileNotFoundError(msg)
 
     if not is_gz_file(args.reads):
-        log.error(f"Reads file {args.reads} must be gzipped")
-        sys.exit()
+        msg = f"Reads file {args.reads} must be gzipped"
+        log.error(msg)
+        raise ValueError(msg)
 
     return args
 


### PR DESCRIPTION
## Summary
- replace bare `except` blocks with `except Exception as e` and log the error
- raise exceptions instead of calling `sys.exit` in library code

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921ae402d0832197a568af7e3148e0